### PR TITLE
fix/reset and mulitple views

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "peerDependencies": {
     "@curvenote/components": "^0.3.3",
     "@curvenote/runtime": "^0.2.8",
-    "@curvenote/schema": "^0.9.0",
+    "@curvenote/schema": "^0.9.2",
     "@date-io/date-fns": "^1.3.13",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
@@ -87,7 +87,7 @@
     "@curvenote/article": "^0.3.0",
     "@curvenote/components": "^0.3.3",
     "@curvenote/runtime": "^0.2.8",
-    "@curvenote/schema": "^0.9.0",
+    "@curvenote/schema": "^0.9.2",
     "@date-io/date-fns": "^1.3.13",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",

--- a/src/store/state/actions.ts
+++ b/src/store/state/actions.ts
@@ -9,6 +9,7 @@ import {
   UNSUBSCRIBE_EDITOR_VIEW,
   RESET_ALL_EDITORS_AND_VIEWS,
   RESET_ALL_VIEWS,
+  RESET_EDITOR_AND_VIEWS,
 } from './types';
 import { AppThunk } from '../types';
 import { getEditorState, getEditorView } from './selectors';
@@ -105,5 +106,16 @@ export function resetAllEditorsAndViews(): EditorActionTypes {
 export function resetAllViews(): EditorActionTypes {
   return {
     type: RESET_ALL_VIEWS,
+  };
+}
+
+export function resetEditorAndViews(stateKey: any): EditorActionTypes {
+  const stateId = opts.transformKeyToId(stateKey);
+  if (stateId == null) throw new Error('Must have a state ID');
+  return {
+    type: RESET_EDITOR_AND_VIEWS,
+    payload: {
+      stateId,
+    },
   };
 }

--- a/src/store/state/reducers.ts
+++ b/src/store/state/reducers.ts
@@ -45,7 +45,7 @@ const editorReducer = (state = initialState, action: EditorActionTypes): Editors
         ...state,
         editors: {
           ...state.editors,
-          [stateId]: { ...editor, viewIds: [...editor.viewIds, viewId] },
+          [stateId]: { ...editor, viewIds: Array.from(new Set([...editor.viewIds, viewId])) },
         },
         views: {
           ...state.views,

--- a/src/store/state/reducers.ts
+++ b/src/store/state/reducers.ts
@@ -8,6 +8,7 @@ import {
   RESET_ALL_VIEWS,
   EditorActionTypes,
   EditorsState,
+  RESET_EDITOR_AND_VIEWS,
 } from './types';
 import { createEditorState } from '../../prosemirror';
 
@@ -66,6 +67,19 @@ const editorReducer = (state = initialState, action: EditorActionTypes): Editors
           Object.entries(state.editors).map(([k, editor]) => [k, { ...editor, viewIds: [] }]),
         ),
         views: {},
+      };
+    }
+    case RESET_EDITOR_AND_VIEWS: {
+      const { stateId } = action.payload;
+      const { [stateId]: editor, ...rest } = state.editors;
+      if (editor === undefined) return state;
+      const views = Object.fromEntries(
+        Object.entries(state.views).filter(([k]) => editor.viewIds.indexOf(k) === -1),
+      );
+      return {
+        ...state,
+        editors: rest,
+        views,
       };
     }
     case UNSUBSCRIBE_EDITOR_VIEW: {

--- a/src/store/state/types.ts
+++ b/src/store/state/types.ts
@@ -8,6 +8,7 @@ export const SUBSCRIBE_EDITOR_VIEW = 'SUBSCRIBE_EDITOR_VIEW';
 export const UNSUBSCRIBE_EDITOR_VIEW = 'UNSUBSCRIBE_EDITOR_VIEW';
 export const RESET_ALL_EDITORS_AND_VIEWS = 'RESET_ALL_EDITORS_AND_VIEWS';
 export const RESET_ALL_VIEWS = 'RESET_ALL_VIEWS';
+export const RESET_EDITOR_AND_VIEWS = 'RESET_EDITOR_AND_VIEWS';
 
 export const UPDATE_EDITOR_STATE = 'UPDATE_EDITOR_STATE';
 
@@ -76,10 +77,18 @@ export interface ResetAllViews {
   type: typeof RESET_ALL_VIEWS;
 }
 
+export interface ResetEditorAndViews {
+  type: typeof RESET_EDITOR_AND_VIEWS;
+  payload: {
+    stateId: string;
+  };
+}
+
 export type EditorActionTypes =
   | InitEditorState
   | UpdateEditorState
   | SubscribeEditorView
   | UnsubscribeEditorView
   | ResetAllEditorsAndViews
-  | ResetAllViews;
+  | ResetAllViews
+  | ResetEditorAndViews;

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,10 @@
     redux-thunk "^2.3.0"
     uuid "^8.3.2"
 
-"@curvenote/schema@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@curvenote/schema/-/schema-0.9.0.tgz#9d281292bdf20d2b6f2f0a200409a03f02c92f5a"
-  integrity sha512-brRK9hylflhqTkEYo//YhiJKOvGagLT5gLJVfD/4qOErfK3HDUYtV0yZUnM5b4dbDRi1xs6xgvdo/A4hvBp8GQ==
+"@curvenote/schema@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@curvenote/schema/-/schema-0.9.2.tgz#bb7db0eca41e47f96a88380fd0b5ae5f85f9ad64"
+  integrity sha512-/0+OIi+qHZZZiSg2Ci4SNp78bl6IqppeRLsiKpayHySmW+Ty8HZR2sm4ncR0GiXeRp/7Y3NWEre4LQPB7BRmtA==
   dependencies:
     "@wordpress/wordcount" "^3.2.2"
     markdown-it "^12.2.0"


### PR DESCRIPTION
 - added a resetEditorAndViews action allowing us to clean up a single editor
 - editor state could have multiple duplicate viewIds, these are now de-duped