### PR TITLE
🫖 Text after links

### DIFF
--- a/cypress/component/link.cy.tsx
+++ b/cypress/component/link.cy.tsx
@@ -170,12 +170,17 @@ describe('generate link while typing', () => {
     });
     return result;
   }
-  async function shouldGenerateLink(input: string, shouldExits: boolean, href = `http://${input}`) {
+  async function shouldGenerateLink(
+    input: string,
+    shouldExits: boolean,
+    href = `http://${input}`,
+    text = input,
+  ) {
     const result = await typeLink(input);
     const anchor = result.container?.querySelector(`a[href="${href}"]`);
     if (shouldExits) {
       if (!assertElExists(anchor)) return;
-      expect(anchor.innerHTML).to.equal(input);
+      expect(anchor.innerHTML).to.equal(text);
     } else {
       expect(anchor).to.be.not.ok;
     }
@@ -185,6 +190,14 @@ describe('generate link while typing', () => {
     await shouldGenerateLink('test.com', true);
     await shouldGenerateLink('test.org', true);
     await shouldGenerateLink('test.net', true);
+  });
+
+  it('should pickup a link with punctuation', async () => {
+    await shouldGenerateLink('test.com.', true, 'http://test.com', 'test.com');
+    await shouldGenerateLink('test.com,', true, 'http://test.com', 'test.com');
+    await shouldGenerateLink('test.com!', true, 'http://test.com', 'test.com');
+    await shouldGenerateLink('test.com;', true, 'http://test.com', 'test.com');
+    await shouldGenerateLink('https://test.com;', true, 'https://test.com', 'https://test.com');
   });
 
   it('should pickup test.xyz', async () => {
@@ -206,7 +219,7 @@ describe('generate link while typing', () => {
     await shouldGenerateLink('http://test.xyz', true, 'http://test.xyz');
   });
 
-  it('should pickup text starting with protocol event tho the link seems unacceptable http://test.md', async () => {
+  it('should pickup text starting with protocol even though the link is not common (http://test.md)', async () => {
     await shouldGenerateLink('http://test.md', true, 'http://test.md');
   });
 

--- a/src/prosemirror/inputrules/rules.ts
+++ b/src/prosemirror/inputrules/rules.ts
@@ -70,22 +70,42 @@ export const copyright = (schema: Schema) => [
   new InputRule(/(\(r\)\s)$/, '® '),
 ];
 
+const ENDING_PUNCTUATION = /([.;,!])$/;
 function normalize(match: string[]) {
-  const url = match[0].slice(0, -1);
+  let url = match[1];
+  const punctuation = url.match(ENDING_PUNCTUATION);
+  if (punctuation) {
+    url = url.replace(ENDING_PUNCTUATION, '');
+  }
   if (validateEmail(url)) {
     return { href: `mailto:${url}`, text: url };
   }
   return { href: normalizeUrl(url) };
 }
+function getLinkText(match: string[]) {
+  const url = match[1];
+  const punctuation = url.match(ENDING_PUNCTUATION);
+  if (punctuation) {
+    return url.replace(ENDING_PUNCTUATION, '');
+  }
+  return url;
+}
+function getTextAfter(match: string[]) {
+  const url = match[1];
+  const punctuation = url.match(ENDING_PUNCTUATION);
+  return punctuation ? `${punctuation[1]}${match[2]}` : match[2];
+}
 
 export const link = (schema: Schema) => [
   markInputRule(TEST_LINK_SPACE, schema.marks.link, {
     getAttrs: normalize,
-    addSpace: true,
+    getText: getLinkText,
+    getTextAfter,
   }),
   markInputRule(TEST_LINK_COMMON_SPACE, schema.marks.link, {
     getAttrs: normalize,
-    addSpace: true,
+    getText: getLinkText,
+    getTextAfter,
   }),
 ];
 

--- a/src/prosemirror/inputrules/utils.ts
+++ b/src/prosemirror/inputrules/utils.ts
@@ -17,7 +17,7 @@ export function markInputRule(
   options?: {
     getAttrs?: GetAttrs;
     getText?: (p: string[]) => string;
-    addSpace?: boolean;
+    getTextAfter?: ((p: string[]) => string) | string;
   },
 ) {
   return new InputRule(regexp, (state, match, start, end) => {
@@ -26,8 +26,9 @@ export function markInputRule(
       TextSelection.create(state.doc, start, end),
     );
     if (parent?.node) return null;
-    const { getAttrs, getText, addSpace } = options ?? {};
+    const { getAttrs, getText, getTextAfter } = options ?? {};
     const attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs;
+    const textAfter = getTextAfter instanceof Function ? getTextAfter(match) : getTextAfter;
     const { tr } = state;
     if (state.doc.rangeHasMark(start, end, markType)) {
       return null;
@@ -38,7 +39,7 @@ export function markInputRule(
     tr.insertText(text);
     tr.addMark(start, start + text.length, mark);
     tr.removeStoredMark(markType);
-    if (addSpace) tr.insertText(' ');
+    if (textAfter) tr.insertText(textAfter);
     return tr;
   });
 }

--- a/src/store/actions/utils.ts
+++ b/src/store/actions/utils.ts
@@ -19,14 +19,16 @@ export const TEST_LINK_COMMON_SPACE =
 export const TEST_LINK_COMMON =
   /^[-a-zA-Z0-9@:%._+~#=]{2,256}\.(?:com|ca|space|xyz|org|app|dev|io|net|gov|edu)\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/;
 
+const VALID_PROTOCOLS = new Set(['http:', 'https:', 'ftp:']);
 export function validateUrl(url: string) {
+  if (url.includes(' ')) return false;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const temp = new URL(url);
+    const valid = new URL(url);
+    if (VALID_PROTOCOLS.has(valid.protocol)) return true;
+    return false;
   } catch (e) {
     return false;
   }
-  return true;
 }
 // used by chromium: https://stackoverflow.com/a/46181/5465086
 export function validateEmail(url: string) {

--- a/src/store/actions/utils.ts
+++ b/src/store/actions/utils.ts
@@ -13,9 +13,9 @@ import { Fragment, Node, NodeType, Schema } from 'prosemirror-model';
 import { opts } from '../../connect';
 
 export const TEST_LINK_SPACE =
-  /((https?:\/\/)(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_+.~#?&//=]*))\s$/;
+  /((?:https?:\/\/)(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,4}\b(?:[-a-zA-Z0-9@:%_+.~#?&//=]*))([\s!,;])$/;
 export const TEST_LINK_COMMON_SPACE =
-  /((https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.(?:com|ca|space|xyz|org|app|dev|io|net|gov|edu)\b([-a-zA-Z0-9@:%_+.~#?&//=]*))\s$/;
+  /((?:https?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.(?:com|ca|space|xyz|org|app|dev|io|net|gov|edu)\b(?:[-a-zA-Z0-9@:%_+.~#?&//=]*))([\s!,;])$/;
 export const TEST_LINK_COMMON =
   /^[-a-zA-Z0-9@:%._+~#=]{2,256}\.(?:com|ca|space|xyz|org|app|dev|io|net|gov|edu)\b([-a-zA-Z0-9@:%_+.~#?&//=]*)$/;
 


### PR DESCRIPTION
This adds some improvements for writing links that end in punctuation:
* curvenote.com,
* curvenote.com!
* curvenote.com;
* curvenote.com,

Tested locally!