### PR TITLE
Provide event to the onArrow handler

### DIFF
--- a/packages/prosemirror-autocomplete/src/decoration.ts
+++ b/packages/prosemirror-autocomplete/src/decoration.ts
@@ -172,17 +172,17 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
             return closeAutocomplete(view);
           case ActionKind.enter: {
             // Only trigger the cancel if it is not expliticly handled in the select
-            const result = reducer({ ...action, kind: ActionKind.enter });
+            const result = reducer({ ...action, kind: ActionKind.enter, event });
             if (result === KEEP_OPEN) return true;
             return result || closeAutocomplete(view);
           }
           case ActionKind.up:
           case ActionKind.down:
-            return Boolean(reducer({ ...action, kind }));
+            return Boolean(reducer({ ...action, kind, event }));
           case ActionKind.left:
           case ActionKind.right:
             if (!type?.allArrowKeys) return false;
-            return Boolean(reducer({ ...action, kind }));
+            return Boolean(reducer({ ...action, kind, event }));
           default:
             break;
         }


### PR DESCRIPTION
I'm trying to implement mention functionality using [CxJS lists](https://docs.cxjs.io/widgets/lists). The problem I encountered is that `onArrow` and `onEnter` handlers do not receive the actual keyboard event which could then be used by the list component to position the cursor and select the desired item. This PR adds `event`, besides `kind`, and other action properties.