### PR TITLE
Include event object in action

### DIFF
--- a/packages/prosemirror-autocomplete/src/decoration.ts
+++ b/packages/prosemirror-autocomplete/src/decoration.ts
@@ -164,6 +164,7 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
           filter,
           range: { from, to },
           type,
+          event,
         };
         switch (kind) {
           case ActionKind.close:


### PR DESCRIPTION
Hi - this is more of a question than a ready-to-go PR. In my app I want to respond differently to [tab] and [enter]. This small change would make that possible.

I'm just going to hack it with patch-package for now, but thought I'd suggest it as it's such a small change. A proper PR would need the types fixing up and possibly a test or two.

Thanks for the plugin - working great for me : )