### PR TITLE
Add autocomplete events

### DIFF
--- a/.changeset/forty-ravens-guess.md
+++ b/.changeset/forty-ravens-guess.md
@@ -1,0 +1,5 @@
+---
+'prosemirror-autocomplete': patch
+---
+
+Add autocomplete events to keypress and expose these to external reducers.

--- a/packages/prosemirror-autocomplete/README.md
+++ b/packages/prosemirror-autocomplete/README.md
@@ -109,7 +109,7 @@ Provide the trigger in the matched group and anything before in a non-capture gr
 
 ## Defining a Reducer
 
-The library does not provide a user interface beyond the [demo code](./demo/index.ts), you will have to do that when you get an action from the autocomplete plugin. You can _either_ use the handlers `onOpen`, `onArrow`, `onFilter`, `onEnter`, and `onClose` _or_ you can define a single reducer that will take over these responsibilities. Note: you cannot use handlers and a reducer.
+The library does not provide a user interface beyond the [demo code](./demo/index.ts), you will have to do that when you get an action from the autocomplete plugin. You can _either_ use the handlers `onOpen`, `onArrow`, `onFilter`, `onEnter`, and `onClose` _or_ you can define a single reducer that will take over these responsibilities. Note: you cannot use handlers and a reducer. You can also access the original keyboard event on the action, as `action.event`. If the action was not created by a keyboard event, that property will not be available.
 
 ```ts
 import { AutocompleteAction, KEEP_OPEN } from 'prosemirror-autocomplete';

--- a/packages/prosemirror-autocomplete/src/decoration.ts
+++ b/packages/prosemirror-autocomplete/src/decoration.ts
@@ -164,6 +164,7 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
           filter,
           range: { from, to },
           type,
+          event,
         };
         switch (kind) {
           case ActionKind.close:

--- a/packages/prosemirror-autocomplete/src/types.ts
+++ b/packages/prosemirror-autocomplete/src/types.ts
@@ -41,6 +41,7 @@ export type AutocompleteAction = {
   filter?: string;
   range: FromTo;
   type: Trigger | null;
+  event?: KeyboardEvent;
 };
 
 export interface OpenAutocomplete {


### PR DESCRIPTION
See #174 and #176 for context/requests from @tslocke and @mstijak.

Added the type to `AutocompleteAction` and updated the Readme slightly.

![image](https://user-images.githubusercontent.com/913249/203612400-14e4cc86-1c29-438f-bf45-1f1c4a459823.png)
