### PR TITLE
[prosemirror-autocomplete] clarify intended meaning of `cancelOnFirstSpace`

### DIFF
--- a/packages/prosemirror-autocomplete/README.md
+++ b/packages/prosemirror-autocomplete/README.md
@@ -103,7 +103,8 @@ Provide the trigger in the matched group and anything before in a non-capture gr
 
 - `name: string`: the trigger is passed in the action, you can use this to descriminate handler calls
 - `trigger: string | RegExp`: used to trigger an autocomplete suggestion - described above
-- `cancelOnFirstSpace?: boolean`, cancels the auto complete on first space, default is true
+- `cancelOnSpace?: boolean` (default `false`) When `true`, a space anywhere in the filter cancels autocompletion. Overrides `cancelOnFirstSpace`.  Default is `false`.
+- `cancelOnFirstSpace?: boolean` (default `true`) When `true`, only a space in the initial position of the filter will cancel autocompletion, while spaces elsewhere in the filter are allowed.  Default is `true`.
 - `allArrowKeys?: boolean`: Use left/right arrow keys, default is false
 - `decorationAttrs?: DecorationAttrs`, passed to the `<span>` element directly through prosemirror
 

--- a/packages/prosemirror-autocomplete/demo/index.ts
+++ b/packages/prosemirror-autocomplete/demo/index.ts
@@ -14,7 +14,7 @@ const options: Options = {
   reducer,
   triggers: [
     // For demo purposes, make the `#` and `@` easier to create
-    { name: 'hashtag', trigger: /(#)$/ },
+    { name: 'hashtag', trigger: /(#)$/, cancelOnSpace: true },
     { name: 'mention', trigger: /(@)$/ },
     { name: 'emoji', trigger: ':' },
     { name: 'link', trigger: '[[', cancelOnFirstSpace: false },

--- a/packages/prosemirror-autocomplete/src/decoration.ts
+++ b/packages/prosemirror-autocomplete/src/decoration.ts
@@ -143,7 +143,6 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
         const checkCancelOnSpace = type?.cancelOnFirstSpace ?? true;
         if (
           checkCancelOnSpace &&
-          filter.length === 0 &&
           (event.key === ' ' || event.key === 'Spacebar')
         ) {
           closeAutocomplete(view);

--- a/packages/prosemirror-autocomplete/src/decoration.ts
+++ b/packages/prosemirror-autocomplete/src/decoration.ts
@@ -140,9 +140,13 @@ export function getDecorationPlugin(reducer: Required<Options>['reducer']) {
         // Be defensive, just in case the trigger doesn't exist
         const filter = text.slice(trigger?.length ?? 1);
 
-        const checkCancelOnSpace = type?.cancelOnFirstSpace ?? true;
+        const cancelOnFirstSpace = type?.cancelOnFirstSpace ?? true;
+        const cancelOnSpace = type?.cancelOnSpace ?? false;
+        const checkCancelOnSpace = cancelOnFirstSpace || cancelOnSpace;
+
         if (
           checkCancelOnSpace &&
+          (cancelOnSpace || filter.length === 0) &&
           (event.key === ' ' || event.key === 'Spacebar')
         ) {
           closeAutocomplete(view);

--- a/packages/prosemirror-autocomplete/src/types.ts
+++ b/packages/prosemirror-autocomplete/src/types.ts
@@ -60,7 +60,12 @@ export type AutocompleteTrMeta = OpenAutocomplete | CloseAutocomplete;
 export type Trigger = {
   name: string;
   trigger: string | RegExp;
-  cancelOnFirstSpace?: boolean; // Default is true
+  /** When `true`, a space anywhere in the filter cancels autocompletion.
+   * Overrides `cancelOnFirstSpace`.  (default: `false`) */
+  cancelOnSpace?: boolean;
+  /** When `true`, a space in the initial position of the filter cancels
+   * autocompletion.  (default: `true`) */
+  cancelOnFirstSpace?: boolean;
   allArrowKeys?: boolean; // Default is false
   decorationAttrs?: DecorationAttrs;
 };


### PR DESCRIPTION
Thanks very much for the `prosemirror-autocomplete` package, it's great!

## `cancelOnFirstSpace`

What's the intended behavior of `cancelOnFirstSpace`?  The docs say:

> `cancelOnFirstSpace?: boolean`, cancels the auto complete on first space, default is true

This could be interpreted in two different ways:

1. the autocomplete will be cancelled the **first time** the user types a space (that is, no spaces are allowed whatsoever)
2. the autocomplete will be cancelled if the **first character** typed after the autocomplete trigger is a space, but after that, spaces are allowed

My desired behavior is the first one -- no spaces allowed, but the code behaves according to the second interpretation:

https://github.com/curvenote/editor/blob/8f576d722fafc4041e2362ad443b2ec6524f932e/packages/prosemirror-autocomplete/src/decoration.ts#L143-L153

## Proposal

I propose the following, which I've implemented in this PR.

* add a new option `cancelOnSpace`, which cancels autocompletion whenever space is pressed
* if `cancelOnSpace = true`, the value of `cancelOnFirstSpace` is ignored
* if `cancelOnSpace = false`, the behavior of `cancelOnFirstSpace` is the same as before

I also added some comments and updated the readme to document this change.

### (Optional) Rename `cancelOnFirstSpace`?

Optionally, I suggest renaming `cancelOnFirstSpace` to `cancelOnInitialSpace`, but I understand if you prefer to keep it the same to avoid a breaking change.

## Conclusion

Happy to make any changes to the PR based on your feedback.  Thanks!